### PR TITLE
merging fixes and closing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This fork was created to address the unfixed issues with the original repository
 # Getting PokeClassic
 This repository builds the following ROM:
 
-* pokeemerald.gba `sha1: 3E4983BADEC574547D7097AC1B3960D1A46489BF`
+* pokeemerald.gba `sha1: D77939F35F8BACA26893D444DA8478347A39699D`
 
 **updated 2/02/2025**
 

--- a/data/maps/BattleTower_2F_Shop/map.json
+++ b/data/maps/BattleTower_2F_Shop/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/BattleTower_3F_Lounge/map.json
+++ b/data/maps/BattleTower_3F_Lounge/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/BattleTower_Basement/map.json
+++ b/data/maps/BattleTower_Basement/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/BattleTower_Entrance/map.json
+++ b/data/maps/BattleTower_Entrance/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeladonCity_Condominiums_1F/map.json
+++ b/data/maps/CeladonCity_Condominiums_1F/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeladonCity_Condominiums_2F/map.json
+++ b/data/maps/CeladonCity_Condominiums_2F/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeladonCity_Condominiums_3F/map.json
+++ b/data/maps/CeladonCity_Condominiums_3F/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeladonCity_Condominiums_Roof/map.json
+++ b/data/maps/CeladonCity_Condominiums_Roof/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_TOWN",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeladonCity_Condominiums_RoofRoom/map.json
+++ b/data/maps/CeladonCity_Condominiums_RoofRoom/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeladonCity_DepartmentStore_1F/map.json
+++ b/data/maps/CeladonCity_DepartmentStore_1F/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeladonCity_DepartmentStore_2F/map.json
+++ b/data/maps/CeladonCity_DepartmentStore_2F/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeladonCity_DepartmentStore_3F/map.json
+++ b/data/maps/CeladonCity_DepartmentStore_3F/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeladonCity_DepartmentStore_4F/map.json
+++ b/data/maps/CeladonCity_DepartmentStore_4F/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeladonCity_DepartmentStore_5F/map.json
+++ b/data/maps/CeladonCity_DepartmentStore_5F/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeladonCity_DepartmentStore_Elevator/map.json
+++ b/data/maps/CeladonCity_DepartmentStore_Elevator/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeladonCity_DepartmentStore_Roof/map.json
+++ b/data/maps/CeladonCity_DepartmentStore_Roof/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_TOWN",
   "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/CeruleanCave_1F/map.json
+++ b/data/maps/CeruleanCave_1F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 7,
       "y": 3,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "CeruleanCave_1F_EventScript_ItemNugget",
-      "flag": "FLAG_HIDE_CERULEAN_CAVE_1F_NUGGET"
+      "flag": "FLAG_HIDE_CERULEAN_CAVE_1F_NUGGET",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 25,
       "y": 5,
       "elevation": 4,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "CeruleanCave_1F_EventScript_ItemMaxElixir",
-      "flag": "FLAG_HIDE_CERULEAN_CAVE_1F_MAX_ELIXIR"
+      "flag": "FLAG_HIDE_CERULEAN_CAVE_1F_MAX_ELIXIR",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 11,
       "y": 16,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "CeruleanCave_1F_EventScript_ItemFullRestore",
-      "flag": "FLAG_HIDE_CERULEAN_CAVE_1F_FULL_RESTORE"
+      "flag": "FLAG_HIDE_CERULEAN_CAVE_1F_FULL_RESTORE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 5,
       "y": 20,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_14"
+      "flag": "FLAG_TEMP_14",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 7,
       "y": 21,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_12"
+      "flag": "FLAG_TEMP_12",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 9,
       "y": 18,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_17"
+      "flag": "FLAG_TEMP_17",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 11,
       "y": 21,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_16"
+      "flag": "FLAG_TEMP_16",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 13,
       "y": 21,
       "elevation": 3,
@@ -124,11 +123,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_13"
+      "flag": "FLAG_TEMP_13",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 14,
       "y": 20,
       "elevation": 3,
@@ -138,7 +137,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_15"
+      "flag": "FLAG_TEMP_15",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/CeruleanCave_2F/map.json
+++ b/data/maps/CeruleanCave_2F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 33,
       "y": 12,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "CeruleanCave_2F_EventScript_ItemFullRestore",
-      "flag": "FLAG_HIDE_CERULEAN_CAVE_2F_FULL_RESTORE"
+      "flag": "FLAG_HIDE_CERULEAN_CAVE_2F_FULL_RESTORE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 29,
       "y": 16,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "CeruleanCave_2F_EventScript_ItemUltraBall",
-      "flag": "FLAG_HIDE_CERULEAN_CAVE_2F_ULTRA_BALL"
+      "flag": "FLAG_HIDE_CERULEAN_CAVE_2F_ULTRA_BALL",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 9,
       "y": 18,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "CeruleanCave_2F_EventScript_ItemPPUp",
-      "flag": "FLAG_HIDE_CERULEAN_CAVE_2F_PP_UP"
+      "flag": "FLAG_HIDE_CERULEAN_CAVE_2F_PP_UP",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 4,
       "y": 12,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_1A"
+      "flag": "FLAG_TEMP_1A",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 9,
       "y": 13,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_17"
+      "flag": "FLAG_TEMP_17",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 10,
       "y": 20,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_1B"
+      "flag": "FLAG_TEMP_1B",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 13,
       "y": 6,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_19"
+      "flag": "FLAG_TEMP_19",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 23,
       "y": 16,
       "elevation": 3,
@@ -124,11 +123,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_18"
+      "flag": "FLAG_TEMP_18",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 25,
       "y": 11,
       "elevation": 3,
@@ -138,11 +137,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_14"
+      "flag": "FLAG_TEMP_14",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 28,
       "y": 20,
       "elevation": 3,
@@ -152,11 +151,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_15"
+      "flag": "FLAG_TEMP_15",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 30,
       "y": 20,
       "elevation": 3,
@@ -166,11 +165,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_16"
+      "flag": "FLAG_TEMP_16",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 33,
       "y": 10,
       "elevation": 3,
@@ -180,11 +179,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_12"
+      "flag": "FLAG_TEMP_12",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 33,
       "y": 9,
       "elevation": 3,
@@ -194,11 +193,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_13"
+      "flag": "FLAG_TEMP_13",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_AMBER",
-      "in_connection": false,
       "x": 4,
       "y": 8,
       "elevation": 3,
@@ -208,11 +207,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "CeruleanCave_2F_EventScript_MewtoniteX",
-      "flag": "FLAG_HIDE_MEWTONITE_X"
+      "flag": "FLAG_HIDE_MEWTONITE_X",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_AMBER",
-      "in_connection": false,
       "x": 19,
       "y": 20,
       "elevation": 3,
@@ -222,7 +221,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "CeruleanCave_2F_EventScript_MewtoniteY",
-      "flag": "FLAG_HIDE_MEWTONITE_Y"
+      "flag": "FLAG_HIDE_MEWTONITE_Y",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/CeruleanCave_B1F/map.json
+++ b/data/maps/CeruleanCave_B1F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 3,
       "y": 4,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_1A"
+      "flag": "FLAG_TEMP_1A",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 2,
       "y": 2,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_17"
+      "flag": "FLAG_TEMP_17",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 4,
       "y": 1,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_18"
+      "flag": "FLAG_TEMP_18",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 6,
       "y": 1,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_19"
+      "flag": "FLAG_TEMP_19",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 35,
       "y": 5,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_16"
+      "flag": "FLAG_TEMP_16",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 37,
       "y": 4,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_15"
+      "flag": "FLAG_TEMP_15",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 38,
       "y": 2,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_13"
+      "flag": "FLAG_TEMP_13",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 37,
       "y": 1,
       "elevation": 3,
@@ -124,11 +123,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_12"
+      "flag": "FLAG_TEMP_12",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 35,
       "y": 1,
       "elevation": 3,
@@ -138,11 +137,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_14"
+      "flag": "FLAG_TEMP_14",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 32,
       "y": 2,
       "elevation": 3,
@@ -152,11 +151,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "CeruleanCave_B1F_EventScript_ItemMaxRevive",
-      "flag": "FLAG_HIDE_CERULEAN_CAVE_B1F_MAX_REVIVE"
+      "flag": "FLAG_HIDE_CERULEAN_CAVE_B1F_MAX_REVIVE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 31,
       "y": 9,
       "elevation": 4,
@@ -166,11 +165,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "CeruleanCave_B1F_EventScript_ItemUltraBall",
-      "flag": "FLAG_HIDE_CERULEAN_CAVE_B1F_ULTRA_BALL"
+      "flag": "FLAG_HIDE_CERULEAN_CAVE_B1F_ULTRA_BALL",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MEWTWO",
-      "in_connection": false,
       "x": 7,
       "y": 12,
       "elevation": 3,
@@ -180,7 +179,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "CeruleanCave_EventScript_Mewtwo",
-      "flag": "FLAG_HIDE_MEWTWO"
+      "flag": "FLAG_HIDE_MEWTWO",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/DiglettsCave_B1F/map.json
+++ b/data/maps/DiglettsCave_B1F/map.json
@@ -133,13 +133,6 @@
 
   ],
   "bg_events": [
-    {
-      "type": "hidden_item",
-      "x": 59,
-      "y": 48,
-      "elevation": 3,
-      "item": "ITEM_HM06_ROCK_SMASH",
-      "flag": "FLAG_TEMP_1"
-    }
+
   ]
 }

--- a/data/maps/MtMoon_1F/map.json
+++ b/data/maps/MtMoon_1F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_BUG_CATCHER",
-      "in_connection": false,
       "x": 7,
       "y": 26,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "MtMoon_1F_EventScript_Kent",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LASS",
-      "in_connection": false,
       "x": 20,
       "y": 26,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "MtMoon_1F_EventScript_Iris",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MANIAC",
-      "in_connection": false,
       "x": 30,
       "y": 35,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "MtMoon_1F_EventScript_Jovan",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BUG_CATCHER",
-      "in_connection": false,
       "x": 36,
       "y": 30,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "MtMoon_1F_EventScript_Robby",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_HIKER",
-      "in_connection": false,
       "x": 7,
       "y": 10,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "1",
       "script": "MtMoon_1F_EventScript_Macros",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LASS",
-      "in_connection": false,
       "x": 33,
       "y": 4,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "MtMoon_1F_EventScript_Miriam",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_YOUNGSTER",
-      "in_connection": false,
       "x": 13,
       "y": 17,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "MtMoon_1F_EventScript_Josh",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 3,
       "y": 2,
       "elevation": 3,
@@ -124,11 +123,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_1F_EventScript_ItemMoonStone",
-      "flag": "FLAG_HIDE_MT_MOON_1F_MOON_STONE"
+      "flag": "FLAG_HIDE_MT_MOON_1F_MOON_STONE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 44,
       "y": 21,
       "elevation": 3,
@@ -138,11 +137,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_1F_EventScript_ItemEscapeRope",
-      "flag": "FLAG_HIDE_MT_MOON_1F_ESCAPE_ROPE"
+      "flag": "FLAG_HIDE_MT_MOON_1F_ESCAPE_ROPE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 42,
       "y": 35,
       "elevation": 3,
@@ -152,11 +151,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_1F_EventScript_ItemRareCandy",
-      "flag": "FLAG_HIDE_MT_MOON_1F_RARE_CANDY"
+      "flag": "FLAG_HIDE_MT_MOON_1F_RARE_CANDY",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 26,
       "y": 32,
       "elevation": 3,
@@ -166,11 +165,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_1F_EventScript_ItemPotion",
-      "flag": "FLAG_HIDE_MT_MOON_1F_POTION"
+      "flag": "FLAG_HIDE_MT_MOON_1F_POTION",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_GREAT_BALL",
-      "in_connection": false,
       "x": 11,
       "y": 35,
       "elevation": 3,
@@ -180,11 +179,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_1F_EventScript_ItemTM09",
-      "flag": "FLAG_HIDE_MT_MOON_1F_TM09"
+      "flag": "FLAG_HIDE_MT_MOON_1F_TM09",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 2,
       "y": 22,
       "elevation": 3,
@@ -194,11 +193,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_1F_EventScript_ItemParalyzeHeal",
-      "flag": "FLAG_HIDE_MT_MOON_1F_PARALYZE_HEAL"
+      "flag": "FLAG_HIDE_MT_MOON_1F_PARALYZE_HEAL",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MAN_4",
-      "in_connection": false,
       "x": 42,
       "y": 7,
       "elevation": 3,
@@ -208,11 +207,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_1F_EventScript_BaldingMan",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 40,
       "y": 9,
       "elevation": 3,
@@ -222,11 +221,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_13"
+      "flag": "FLAG_TEMP_13",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 40,
       "y": 7,
       "elevation": 3,
@@ -236,11 +235,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_12"
+      "flag": "FLAG_TEMP_12",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 43,
       "y": 9,
       "elevation": 3,
@@ -250,7 +249,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_14"
+      "flag": "FLAG_TEMP_14",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/MtMoon_B1F/map.json
+++ b/data/maps/MtMoon_B1F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 41,
       "y": 34,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_15"
+      "flag": "FLAG_TEMP_15",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 17,
       "y": 3,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_12"
+      "flag": "FLAG_TEMP_12",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 7,
       "y": 16,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_11"
+      "flag": "FLAG_TEMP_11",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 6,
       "y": 15,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_10"
+      "flag": "FLAG_TEMP_10",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 37,
       "y": 4,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_13"
+      "flag": "FLAG_TEMP_13",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 41,
       "y": 2,
       "elevation": 3,
@@ -96,7 +95,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_14"
+      "flag": "FLAG_TEMP_14",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/MtMoon_B2F/map.json
+++ b/data/maps/MtMoon_B2F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_FOSSIL",
-      "in_connection": false,
       "x": 13,
       "y": 7,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_B2F_EventScript_DomeFossil",
-      "flag": "FLAG_HIDE_DOME_FOSSIL"
+      "flag": "FLAG_HIDE_DOME_FOSSIL",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_FOSSIL",
-      "in_connection": false,
       "x": 14,
       "y": 7,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_B2F_EventScript_HelixFossil",
-      "flag": "FLAG_HIDE_HELIX_FOSSIL"
+      "flag": "FLAG_HIDE_HELIX_FOSSIL",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MANIAC",
-      "in_connection": false,
       "x": 13,
       "y": 11,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_B2F_EventScript_Miguel",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 37,
       "y": 21,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "MtMoon_B2F_EventScript_Grunt4",
-      "flag": "FLAG_HIDE_MT_MOON_ROCKETS"
+      "flag": "FLAG_HIDE_MT_MOON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 12,
       "y": 20,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "MtMoon_B2F_EventScript_Grunt1",
-      "flag": "FLAG_HIDE_MT_MOON_ROCKETS"
+      "flag": "FLAG_HIDE_MT_MOON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 35,
       "y": 12,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "MtMoon_B2F_EventScript_Grunt3",
-      "flag": "FLAG_HIDE_MT_MOON_ROCKETS"
+      "flag": "FLAG_HIDE_MT_MOON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 18,
       "y": 27,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "MtMoon_B2F_EventScript_Grunt2",
-      "flag": "FLAG_HIDE_MT_MOON_ROCKETS"
+      "flag": "FLAG_HIDE_MT_MOON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_GREAT_BALL",
-      "in_connection": false,
       "x": 35,
       "y": 5,
       "elevation": 3,
@@ -124,11 +123,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_B2F_EventScript_ItemTM46",
-      "flag": "FLAG_HIDE_MT_MOON_B2F_TM46"
+      "flag": "FLAG_HIDE_MT_MOON_B2F_TM46",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 30,
       "y": 26,
       "elevation": 3,
@@ -138,11 +137,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_B2F_EventScript_ItemStarPiece",
-      "flag": "FLAG_HIDE_MT_MOON_B2F_STAR_PIECE"
+      "flag": "FLAG_HIDE_MT_MOON_B2F_STAR_PIECE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 3,
       "y": 11,
       "elevation": 3,
@@ -152,11 +151,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_B2F_EventScript_ItemAntidote",
-      "flag": "FLAG_HIDE_MT_MOON_B2F_ANTIDOTE"
+      "flag": "FLAG_HIDE_MT_MOON_B2F_ANTIDOTE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 24,
       "y": 6,
       "elevation": 3,
@@ -166,11 +165,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MtMoon_B2F_EventScript_ItemRevive",
-      "flag": "FLAG_HIDE_MT_MOON_B2F_REVIVE"
+      "flag": "FLAG_HIDE_MT_MOON_B2F_REVIVE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_JESSIE",
-      "in_connection": false,
       "x": 12,
       "y": 5,
       "elevation": 3,
@@ -180,11 +179,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "NULL",
-      "flag": "FLAG_HIDE_MT_MOON_JESSIE_JAMES"
+      "flag": "FLAG_HIDE_MT_MOON_JESSIE_JAMES",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_JAMES",
-      "in_connection": false,
       "x": 12,
       "y": 6,
       "elevation": 3,
@@ -194,11 +193,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "NULL",
-      "flag": "FLAG_HIDE_MT_MOON_JESSIE_JAMES"
+      "flag": "FLAG_HIDE_MT_MOON_JESSIE_JAMES",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 26,
       "y": 5,
       "elevation": 3,
@@ -208,11 +207,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_14"
+      "flag": "FLAG_TEMP_14",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 31,
       "y": 6,
       "elevation": 3,
@@ -222,11 +221,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_15"
+      "flag": "FLAG_TEMP_15",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 41,
       "y": 6,
       "elevation": 3,
@@ -236,11 +235,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_16"
+      "flag": "FLAG_TEMP_16",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 15,
       "y": 31,
       "elevation": 3,
@@ -250,11 +249,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_12"
+      "flag": "FLAG_TEMP_12",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 20,
       "y": 21,
       "elevation": 3,
@@ -264,11 +263,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_11"
+      "flag": "FLAG_TEMP_11",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 8,
       "y": 16,
       "elevation": 3,
@@ -278,11 +277,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_10"
+      "flag": "FLAG_TEMP_10",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 33,
       "y": 27,
       "elevation": 3,
@@ -292,7 +291,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_13"
+      "flag": "FLAG_TEMP_13",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/PokemonMansion_1F/map.json
+++ b/data/maps/PokemonMansion_1F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_YOUNGSTER",
-      "in_connection": false,
       "x": 8,
       "y": 8,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "1",
       "script": "PokemonMansion_1F_EventScript_Johnson",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST_1",
-      "in_connection": false,
       "x": 22,
       "y": 24,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "PokemonMansion_1F_EventScript_Ted",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 22,
       "y": 6,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonMansion_1F_EventScript_ItemEscapeRope",
-      "flag": "FLAG_HIDE_POKEMON_MANSION_1F_ESCAPE_ROPE"
+      "flag": "FLAG_HIDE_POKEMON_MANSION_1F_ESCAPE_ROPE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 27,
       "y": 15,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonMansion_1F_EventScript_ItemProtein",
-      "flag": "FLAG_HIDE_POKEMON_MANSION_1F_PROTEIN"
+      "flag": "FLAG_HIDE_POKEMON_MANSION_1F_PROTEIN",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 29,
       "y": 32,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonMansion_1F_EventScript_ItemCarbos",
-      "flag": "FLAG_HIDE_POKEMON_MANSION_1F_CARBOS"
+      "flag": "FLAG_HIDE_POKEMON_MANSION_1F_CARBOS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 34,
       "y": 31,
       "elevation": 3,
@@ -96,7 +95,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonMansion_1F_EventScript_ItemBlackSludge",
-      "flag": "FLAG_GOT_BLACK_SLUDGE"
+      "flag": "FLAG_GOT_BLACK_SLUDGE",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/PokemonMansion_2F/map.json
+++ b/data/maps/PokemonMansion_2F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_BURGLAR",
-      "in_connection": false,
       "x": 5,
       "y": 23,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "1",
       "script": "PokemonMansion_2F_EventScript_Arnie",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 18,
       "y": 23,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonMansion_2F_EventScript_ItemZinc",
-      "flag": "FLAG_HIDE_POKEMON_MANSION_2F_ZINC"
+      "flag": "FLAG_HIDE_POKEMON_MANSION_2F_ZINC",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 35,
       "y": 17,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonMansion_2F_EventScript_ItemHPUp",
-      "flag": "FLAG_HIDE_POKEMON_MANSION_2F_HP_UP"
+      "flag": "FLAG_HIDE_POKEMON_MANSION_2F_HP_UP",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 36,
       "y": 8,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonMansion_2F_EventScript_ItemCalcium",
-      "flag": "FLAG_HIDE_POKEMON_MANSION_2F_CALCIUM"
+      "flag": "FLAG_HIDE_POKEMON_MANSION_2F_CALCIUM",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_AMBER",
-      "in_connection": false,
       "x": 20,
       "y": 17,
       "elevation": 3,
@@ -82,7 +81,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonMansion_2F_EventScript_CharizarditeX",
-      "flag": "FLAG_HIDE_CHARIZARDITE_X"
+      "flag": "FLAG_HIDE_CHARIZARDITE_X",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/PokemonMansion_3F/map.json
+++ b/data/maps/PokemonMansion_3F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 32,
       "y": 6,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonMansion_3F_EventScript_ItemIron",
-      "flag": "FLAG_HIDE_POKEMON_MANSION_3F_IRON"
+      "flag": "FLAG_HIDE_POKEMON_MANSION_3F_IRON",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 9,
       "y": 19,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonMansion_3F_EventScript_ItemMaxPotion",
-      "flag": "FLAG_HIDE_POKEMON_MANSION_3F_MAX_POTION"
+      "flag": "FLAG_HIDE_POKEMON_MANSION_3F_MAX_POTION",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BURGLAR",
-      "in_connection": false,
       "x": 7,
       "y": 13,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "1",
       "script": "PokemonMansion_3F_EventScript_Simon",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST_1",
-      "in_connection": false,
       "x": 22,
       "y": 13,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "1",
       "script": "PokemonMansion_3F_EventScript_Braydon",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 1,
       "y": 4,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonMansion_3F_EventScript_ItemCharcoal",
-      "flag": "FLAG_HIDE_POKEMON_MANSION_3F_CHARCOAL"
+      "flag": "FLAG_HIDE_POKEMON_MANSION_3F_CHARCOAL",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_AMBER",
-      "in_connection": false,
       "x": 1,
       "y": 13,
       "elevation": 3,
@@ -96,7 +95,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonMansion_3F_EventScript_CharizarditeY",
-      "flag": "FLAG_HIDE_CHARIZARDITE_Y"
+      "flag": "FLAG_HIDE_CHARIZARDITE_Y",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/PokemonTower_1F/map.json
+++ b/data/maps/PokemonTower_1F/map.json
@@ -9,14 +9,13 @@
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
   "allow_escaping": true,
-  "allow_running": false,
+  "allow_running": true,
   "show_map_name": true,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 18,
       "y": 13,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_1F_EventScript_WorkerF",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 18,
       "y": 7,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_1F_EventScript_Channeler",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LADY",
-      "in_connection": false,
       "x": 15,
       "y": 6,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_1F_EventScript_Woman1",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_3",
-      "in_connection": false,
       "x": 7,
       "y": 8,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_1F_EventScript_Woman2",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MAN_4",
-      "in_connection": false,
       "x": 8,
       "y": 12,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_1F_EventScript_BaldingMan",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CUEBALL",
-      "in_connection": false,
       "x": 9,
       "y": 2,
       "elevation": 3,
@@ -96,7 +95,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_1F_EventScript_CueBall",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/PokemonTower_2F/map.json
+++ b/data/maps/PokemonTower_2F/map.json
@@ -9,14 +9,13 @@
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
   "allow_escaping": true,
-  "allow_running": false,
+  "allow_running": true,
   "show_map_name": true,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_BLUE",
-      "in_connection": false,
       "x": 16,
       "y": 5,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "0x0",
-      "flag": "FLAG_HIDE_RIVAL_IN_POKEMON_TOWER"
+      "flag": "FLAG_HIDE_RIVAL_IN_POKEMON_TOWER",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 3,
       "y": 7,
       "elevation": 0,
@@ -40,7 +39,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_2F_EventScript_Channeler",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/PokemonTower_3F/map.json
+++ b/data/maps/PokemonTower_3F/map.json
@@ -9,14 +9,13 @@
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
   "allow_escaping": true,
-  "allow_running": false,
+  "allow_running": true,
   "show_map_name": true,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 13,
       "y": 2,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_3F_EventScript_ItemEscapeRope",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_3F_ESCAPE_ROPE"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_3F_ESCAPE_ROPE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 12,
       "y": 4,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "PokemonTower_3F_EventScript_Hope",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 9,
       "y": 9,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "PokemonTower_3F_EventScript_Carly",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 10,
       "y": 14,
       "elevation": 3,
@@ -68,7 +67,8 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "PokemonTower_3F_EventScript_Patricia",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/PokemonTower_4F/map.json
+++ b/data/maps/PokemonTower_4F/map.json
@@ -9,14 +9,13 @@
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
   "allow_escaping": true,
-  "allow_running": false,
+  "allow_running": true,
   "show_map_name": true,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 17,
       "y": 7,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "PokemonTower_4F_EventScript_Laurel",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 15,
       "y": 13,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "5",
       "script": "PokemonTower_4F_EventScript_Jody",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 4,
       "y": 12,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "PokemonTower_4F_EventScript_Paula",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 8,
       "y": 11,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_4F_EventScript_ItemAwakening",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_4F_AWAKENING"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_4F_AWAKENING",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 12,
       "y": 11,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_4F_EventScript_ItemElixir",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_4F_ELIXIR"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_4F_ELIXIR",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 11,
       "y": 16,
       "elevation": 3,
@@ -96,7 +95,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_4F_EventScript_ItemGreatBall",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_4F_GREAT_BALL"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_4F_GREAT_BALL",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/PokemonTower_5F/map.json
+++ b/data/maps/PokemonTower_5F/map.json
@@ -9,14 +9,13 @@
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
   "allow_escaping": true,
-  "allow_running": false,
+  "allow_running": true,
   "show_map_name": true,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 11,
       "y": 4,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "PokemonTower_5F_EventScript_Ruth",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 19,
       "y": 7,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "PokemonTower_5F_EventScript_Tammy",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 12,
       "y": 8,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_5F_EventScript_Channeler",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 7,
       "y": 12,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "PokemonTower_5F_EventScript_Karina",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 11,
       "y": 16,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "PokemonTower_5F_EventScript_Janae",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 6,
       "y": 16,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_5F_EventScript_ItemNugget",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_5F_NUGGET"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_5F_NUGGET",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 11,
       "y": 9,
       "elevation": 3,
@@ -110,7 +109,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_5F_EventScript_ItemCleanseTag",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_5F_CLEANSE_TAG"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_5F_CLEANSE_TAG",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/PokemonTower_6F/map.json
+++ b/data/maps/PokemonTower_6F/map.json
@@ -9,14 +9,13 @@
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
   "allow_escaping": true,
-  "allow_running": false,
+  "allow_running": true,
   "show_map_name": true,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 15,
       "y": 15,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_6F_EventScript_ItemXAccuracy",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_6F_X_ACCURACY"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_6F_X_ACCURACY",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 5,
       "y": 15,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_6F_EventScript_ItemRareCandy",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_6F_RARE_CANDY"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_6F_RARE_CANDY",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 13,
       "y": 10,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "PokemonTower_6F_EventScript_Angelica",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 18,
       "y": 6,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "PokemonTower_6F_EventScript_Jennifer",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CHANNELER",
-      "in_connection": false,
       "x": 9,
       "y": 6,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "PokemonTower_6F_EventScript_Emilia",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CUBONE",
-      "in_connection": false,
       "x": 5,
       "y": 9,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "NULL",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_CUBONE"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_CUBONE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MAROWAK_GHOST",
-      "in_connection": false,
       "x": 10,
       "y": 16,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "NULL",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_MAROWAK"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_MAROWAK",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_AMBER",
-      "in_connection": false,
       "x": 3,
       "y": 14,
       "elevation": 3,
@@ -124,7 +123,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_6F_EventScript_Gengarite",
-      "flag": "FLAG_HIDE_GENGARITE"
+      "flag": "FLAG_HIDE_GENGARITE",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/PokemonTower_7F/map.json
+++ b/data/maps/PokemonTower_7F/map.json
@@ -9,14 +9,13 @@
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": false,
   "allow_escaping": true,
-  "allow_running": false,
+  "allow_running": true,
   "show_map_name": true,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 9,
       "y": 10,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "PokemonTower_7F_EventScript_Grunt1",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_ROCKET_1"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_ROCKET_1",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 13,
       "y": 8,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "PokemonTower_7F_EventScript_Grunt2",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_ROCKET_2"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_ROCKET_2",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 9,
       "y": 6,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "PokemonTower_7F_EventScript_Grunt3",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_ROCKET_3"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_ROCKET_3",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_JESSIE",
-      "in_connection": false,
       "x": 10,
       "y": 13,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "NULL",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_JESSIE_JAMES"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_JESSIE_JAMES",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_JAMES",
-      "in_connection": false,
       "x": 12,
       "y": 13,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "NULL",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_JESSIE_JAMES"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_JESSIE_JAMES",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MR_FUJI",
-      "in_connection": false,
       "x": 11,
       "y": 4,
       "elevation": 3,
@@ -96,7 +95,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PokemonTower_7F_EventScript_MrFuji",
-      "flag": "FLAG_HIDE_POKEMON_TOWER_FUJI"
+      "flag": "FLAG_HIDE_POKEMON_TOWER_FUJI",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/RocketHideout_B1F/map.json
+++ b/data/maps/RocketHideout_B1F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 4,
       "y": 9,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "5",
       "script": "RocketHideout_B1F_EventScript_Grunt2",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 24,
       "y": 12,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "RocketHideout_B1F_EventScript_Grunt1",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 10,
       "y": 22,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "RocketHideout_B1F_EventScript_Grunt3",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 6,
       "y": 32,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "RocketHideout_B1F_EventScript_Grunt4",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 21,
       "y": 27,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "RocketHideout_B1F_EventScript_Grunt5",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 5,
       "y": 16,
       "elevation": 0,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B1F_EventScript_ItemEscapeRope",
-      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B1F_ESCAPE_ROPE"
+      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B1F_ESCAPE_ROPE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 1,
       "y": 22,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B1F_EventScript_ItemHyperPotion",
-      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B1F_HYPER_POTION"
+      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B1F_HYPER_POTION",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BURGLAR",
-      "in_connection": false,
       "x": 15,
       "y": 6,
       "elevation": 3,
@@ -124,11 +123,11 @@
       "trainer_type": "TRAINER_TYPE_SEE_ALL_DIRECTIONS",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "RocketHideout_Burglars_TM13",
-      "flag": "FLAG_HIDE_ROCKET_BURGLARS"
+      "flag": "FLAG_HIDE_ROCKET_BURGLARS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BURGLAR",
-      "in_connection": false,
       "x": 6,
       "y": 27,
       "elevation": 3,
@@ -138,7 +137,8 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "RocketHideout_Burglars_TM23",
-      "flag": "FLAG_HIDE_ROCKET_BURGLARS"
+      "flag": "FLAG_HIDE_ROCKET_BURGLARS",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/RocketHideout_B1F/scripts.inc
+++ b/data/maps/RocketHideout_B1F/scripts.inc
@@ -4,7 +4,7 @@ RocketHideout_B1F_MapScripts::
 	.byte 0
 
 RocketHideout_B1F_OnLoad::
-	call_if_not_defeated TRAINER_TEAM_ROCKET_GRUNT_12 RocketHideout_B1F_EventScript_SetBarrier
+	call_if_not_defeated TRAINER_BOSS_GIOVANNI, RocketHideout_B1F_EventScript_SetBarrier
 	end
 
 RocketHideout_B1F_OnTransition::

--- a/data/maps/RocketHideout_B2F/map.json
+++ b/data/maps/RocketHideout_B2F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 20,
       "y": 6,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "RocketHideout_B2F_EventScript_Grunt",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 15,
       "y": 3,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B2F_EventScript_ItemXSpeed",
-      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B2F_X_SPEED"
+      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B2F_X_SPEED",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_GREAT_BALL",
-      "in_connection": false,
       "x": 5,
       "y": 7,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B2F_EventScript_ItemTM12",
-      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B2F_TM12"
+      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B2F_TM12",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 2,
       "y": 5,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B2F_EventScript_ItemMoonStone",
-      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B2F_MOON_STONE"
+      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B2F_MOON_STONE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 0,
       "y": 14,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B2F_EventScript_ItemSuperPotion",
-      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B2F_SUPER_POTION"
+      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B2F_SUPER_POTION",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BURGLAR",
-      "in_connection": false,
       "x": 22,
       "y": 16,
       "elevation": 3,
@@ -96,7 +95,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_Burglars_TM24",
-      "flag": "FLAG_HIDE_ROCKET_BURGLARS"
+      "flag": "FLAG_HIDE_ROCKET_BURGLARS",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/RocketHideout_B3F/map.json
+++ b/data/maps/RocketHideout_B3F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 12,
       "y": 12,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B3F_EventScript_ItemRareCandy",
-      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B3F_RARE_CANDY"
+      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B3F_RARE_CANDY",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_GREAT_BALL",
-      "in_connection": false,
       "x": 19,
       "y": 14,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B3F_EventScript_ItemTM21",
-      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B3F_TM21"
+      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B3F_TM21",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 14,
       "y": 24,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B3F_EventScript_ItemBlackGlasses",
-      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B3F_BLACK_GLASSES"
+      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B3F_BLACK_GLASSES",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 2,
       "y": 20,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "RocketHideout_B3F_EventScript_Grunt1",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 19,
       "y": 9,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "RocketHideout_B3F_EventScript_Grunt2",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BURGLAR",
-      "in_connection": false,
       "x": 9,
       "y": 3,
       "elevation": 3,
@@ -96,7 +95,8 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "RocketHideout_Burglars_TM30",
-      "flag": "FLAG_HIDE_ROCKET_BURGLARS"
+      "flag": "FLAG_HIDE_ROCKET_BURGLARS",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/RocketHideout_B4F/map.json
+++ b/data/maps/RocketHideout_B4F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_GIOVANNI",
-      "in_connection": false,
       "x": 19,
       "y": 4,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B4F_EventScript_Giovanni",
-      "flag": "FLAG_HIDE_HIDEOUT_GIOVANNI"
+      "flag": "FLAG_HIDE_HIDEOUT_GIOVANNI",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CUBONE",
-      "in_connection": false,
       "x": 20,
       "y": 5,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B4F_EventScript_Cubone",
-      "flag": "FLAG_HIDE_HIDEOUT_CUBONE"
+      "flag": "FLAG_HIDE_HIDEOUT_CUBONE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_JAMES",
-      "in_connection": false,
       "x": 19,
       "y": 11,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "RocketHideout_B4F_EventScript_James",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 16,
       "y": 14,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B4F_EventScript_Grunt2",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 19,
       "y": 14,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B4F_EventScript_Grunt3",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_JESSIE",
-      "in_connection": false,
       "x": 16,
       "y": 11,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "RocketHideout_B4F_EventScript_Jessie",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 3,
       "y": 2,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B4F_EventScript_LiftKey",
-      "flag": "FLAG_HIDE_LIFT_KEY"
+      "flag": "FLAG_HIDE_LIFT_KEY",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 1,
       "y": 6,
       "elevation": 3,
@@ -124,11 +123,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B4F_EventScript_ItemTM49",
-      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B4F_TM49"
+      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B4F_TM49",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 4,
       "y": 14,
       "elevation": 0,
@@ -138,11 +137,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B4F_EventScript_ItemMaxEther",
-      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B4F_MAX_ETHER"
+      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B4F_MAX_ETHER",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 6,
       "y": 23,
       "elevation": 0,
@@ -152,11 +151,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "RocketHideout_B4F_EventScript_ItemCalcium",
-      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B4F_CALCIUM"
+      "flag": "FLAG_HIDE_ROCKET_HIDEOUT_B4F_CALCIUM",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 4,
       "y": 2,
       "elevation": 3,
@@ -166,11 +165,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "RocketHideout_B4F_EventScript_Grunt1",
-      "flag": "FLAG_HIDE_CELADON_ROCKETS"
+      "flag": "FLAG_HIDE_CELADON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BURGLAR",
-      "in_connection": false,
       "x": 11,
       "y": 7,
       "elevation": 3,
@@ -180,11 +179,11 @@
       "trainer_type": "TRAINER_TYPE_SEE_ALL_DIRECTIONS",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "RocketHideout_Burglars_TM35",
-      "flag": "FLAG_HIDE_ROCKET_BURGLARS"
+      "flag": "FLAG_HIDE_ROCKET_BURGLARS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BURGLAR",
-      "in_connection": false,
       "x": 4,
       "y": 23,
       "elevation": 3,
@@ -194,7 +193,8 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "RocketHideout_Burglars_TM36",
-      "flag": "FLAG_HIDE_ROCKET_BURGLARS"
+      "flag": "FLAG_HIDE_ROCKET_BURGLARS",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/SeafoamIslands_1F/map.json
+++ b/data/maps/SeafoamIslands_1F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 22,
       "y": 12,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "FLAG_HIDE_SEAFOAM_B1F_BOULDER_1",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "FLAG_HIDE_SEAFOAM_1F_BOULDER_1"
+      "flag": "FLAG_HIDE_SEAFOAM_1F_BOULDER_1",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 32,
       "y": 9,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "FLAG_HIDE_SEAFOAM_B1F_BOULDER_2",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "FLAG_HIDE_SEAFOAM_1F_BOULDER_2"
+      "flag": "FLAG_HIDE_SEAFOAM_1F_BOULDER_2",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 11,
       "y": 8,
       "elevation": 3,
@@ -54,7 +53,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SeafoamIslands_1F_EventScript_ItemIceHeal",
-      "flag": "FLAG_HIDE_SEAFOAM_ISLANDS_1F_ICE_HEAL"
+      "flag": "FLAG_HIDE_SEAFOAM_ISLANDS_1F_ICE_HEAL",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/SeafoamIslands_B1F/map.json
+++ b/data/maps/SeafoamIslands_B1F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 22,
       "y": 8,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "FLAG_HIDE_SEAFOAM_B2F_BOULDER_1",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "FLAG_HIDE_SEAFOAM_B1F_BOULDER_1"
+      "flag": "FLAG_HIDE_SEAFOAM_B1F_BOULDER_1",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 30,
       "y": 8,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "FLAG_HIDE_SEAFOAM_B2F_BOULDER_2",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "FLAG_HIDE_SEAFOAM_B1F_BOULDER_2"
+      "flag": "FLAG_HIDE_SEAFOAM_B1F_BOULDER_2",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 24,
       "y": 14,
       "elevation": 4,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SeafoamIslands_B1F_EventScript_ItemRevive",
-      "flag": "FLAG_HIDE_SEAFOAM_ISLANDS_B1F_REVIVE"
+      "flag": "FLAG_HIDE_SEAFOAM_ISLANDS_B1F_REVIVE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 19,
       "y": 18,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SeafoamIslands_B1F_EventScript_ItemWaterStone",
-      "flag": "FLAG_HIDE_SEAFOAM_ISLANDS_B1F_WATER_STONE"
+      "flag": "FLAG_HIDE_SEAFOAM_ISLANDS_B1F_WATER_STONE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_AMBER",
-      "in_connection": false,
       "x": 13,
       "y": 3,
       "elevation": 3,
@@ -82,7 +81,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SeafoamIslands_B1F_EventScript_Gyaradosite",
-      "flag": "FLAG_HIDE_GYARDOSITE"
+      "flag": "FLAG_HIDE_GYARDOSITE",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/SeafoamIslands_B2F/map.json
+++ b/data/maps/SeafoamIslands_B2F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 22,
       "y": 8,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_1",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "FLAG_HIDE_SEAFOAM_B2F_BOULDER_1"
+      "flag": "FLAG_HIDE_SEAFOAM_B2F_BOULDER_1",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 30,
       "y": 8,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_2",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "FLAG_HIDE_SEAFOAM_B2F_BOULDER_2"
+      "flag": "FLAG_HIDE_SEAFOAM_B2F_BOULDER_2",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 18,
       "y": 15,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SeafoamIslands_B2F_EventScript_ItemBigPearl",
-      "flag": "FLAG_HIDE_SEAFOAM_ISLANDS_B2F_BIG_PEARL"
+      "flag": "FLAG_HIDE_SEAFOAM_ISLANDS_B2F_BIG_PEARL",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 12,
       "y": 9,
       "elevation": 3,
@@ -68,7 +67,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SeafoamIslands_B2F_EventScript_ItemPowerStone",
-      "flag": "FLAG_HIDE_SEAFOAM_ISLANDS_B2F_POWER_STONE"
+      "flag": "FLAG_HIDE_SEAFOAM_ISLANDS_B2F_POWER_STONE",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/SeafoamIslands_B3F/map.json
+++ b/data/maps/SeafoamIslands_B3F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 23,
       "y": 8,
       "elevation": 1,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "0x0",
-      "flag": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_1"
+      "flag": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_1",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 24,
       "y": 8,
       "elevation": 1,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "0x0",
-      "flag": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_2"
+      "flag": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_2",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 12,
       "y": 16,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "FLAG_HIDE_SEAFOAM_B4F_BOULDER_2",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_5"
+      "flag": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_5",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 13,
       "y": 16,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_6"
+      "flag": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_6",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 9,
       "y": 16,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_4"
+      "flag": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_4",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 6,
       "y": 17,
       "elevation": 3,
@@ -96,7 +95,8 @@
       "trainer_type": "FLAG_HIDE_SEAFOAM_B4F_BOULDER_1",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_3"
+      "flag": "FLAG_HIDE_SEAFOAM_B3F_BOULDER_3",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/SeafoamIslands_B4F/map.json
+++ b/data/maps/SeafoamIslands_B4F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 8,
       "y": 18,
       "elevation": 1,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "0x0",
-      "flag": "FLAG_HIDE_SEAFOAM_B4F_BOULDER_1"
+      "flag": "FLAG_HIDE_SEAFOAM_B4F_BOULDER_1",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 9,
       "y": 18,
       "elevation": 1,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "0x0",
-      "flag": "FLAG_HIDE_SEAFOAM_B4F_BOULDER_2"
+      "flag": "FLAG_HIDE_SEAFOAM_B4F_BOULDER_2",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 22,
       "y": 19,
       "elevation": 4,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SeafoamIslands_B4F_EventScript_ItemUltraBall",
-      "flag": "FLAG_HIDE_SEAFOAM_ISLANDS_B4F_ULTRA_BALL"
+      "flag": "FLAG_HIDE_SEAFOAM_ISLANDS_B4F_ULTRA_BALL",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ARTICUNO",
-      "in_connection": false,
       "x": 9,
       "y": 2,
       "elevation": 4,
@@ -68,7 +67,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SeafoamIslands_B4F_EventScript_Articuno",
-      "flag": "FLAG_HIDE_ARTICUNO"
+      "flag": "FLAG_HIDE_ARTICUNO",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/SilphCo_11F/scripts.inc
+++ b/data/maps/SilphCo_11F/scripts.inc
@@ -503,10 +503,10 @@ SilphCo_11F_LookerMovement_Exit1::
 	walk_left
 	walk_left
 	walk_left
-	walk_up
-	walk_up
-	walk_up
-	walk_up
+	walk_down
+	walk_down
+	walk_down
+	walk_down
 	step_end
 
 SilphCo_11F_RocketMovement_Exit2::

--- a/data/maps/SilphCo_5F/map.json
+++ b/data/maps/SilphCo_5F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST_1",
-      "in_connection": false,
       "x": 2,
       "y": 7,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_5F_EventScript_Scientist",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST_1",
-      "in_connection": false,
       "x": 11,
       "y": 6,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "1",
       "script": "SilphCo_5F_EventScript_Beau",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 9,
       "y": 21,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "SilphCo_5F_EventScript_Grunt1",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 35,
       "y": 7,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "SilphCo_5F_EventScript_Grunt2",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 22,
       "y": 21,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_5F_EventScript_ItemCardKey",
-      "flag": "FLAG_HIDE_SILPH_CO_5F_CARD_KEY"
+      "flag": "FLAG_HIDE_SILPH_CO_5F_CARD_KEY",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
-      "in_connection": false,
       "x": 16,
       "y": 13,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_5F_EventScript_WorkerM",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MAN_2",
-      "in_connection": false,
       "x": 23,
       "y": 13,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "SilphCo_5F_EventScript_Dalton",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 4,
       "y": 9,
       "elevation": 3,
@@ -124,11 +123,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_5F_EventScript_ItemProtein",
-      "flag": "FLAG_HIDE_SILPH_CO_5F_PROTEIN"
+      "flag": "FLAG_HIDE_SILPH_CO_5F_PROTEIN",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_GREAT_BALL",
-      "in_connection": false,
       "x": 1,
       "y": 18,
       "elevation": 3,
@@ -138,7 +137,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_5F_EventScript_ItemTM01",
-      "flag": "FLAG_HIDE_SILPH_CO_5F_TM01"
+      "flag": "FLAG_HIDE_SILPH_CO_5F_TM01",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/SilphCo_6F/map.json
+++ b/data/maps/SilphCo_6F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 21,
       "y": 5,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "SilphCo_6F_EventScript_Grunt1",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_DEVON_EMPLOYEE",
-      "in_connection": false,
       "x": 23,
       "y": 9,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_6F_EventScript_WorkerM1",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
-      "in_connection": false,
       "x": 24,
       "y": 9,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_6F_EventScript_WorkerF1",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MART_EMPLOYEE",
-      "in_connection": false,
       "x": 22,
       "y": 13,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_6F_EventScript_WorkerM2",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
-      "in_connection": false,
       "x": 16,
       "y": 12,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_6F_EventScript_WorkerF2",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_DEVON_EMPLOYEE",
-      "in_connection": false,
       "x": 14,
       "y": 9,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_6F_EventScript_WorkerM3",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST_1",
-      "in_connection": false,
       "x": 9,
       "y": 11,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "SilphCo_6F_EventScript_Taylor",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 18,
       "y": 17,
       "elevation": 3,
@@ -124,11 +123,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "SilphCo_6F_EventScript_Grunt2",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 2,
       "y": 14,
       "elevation": 3,
@@ -138,11 +137,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_6F_EventScript_ItemHPUp",
-      "flag": "FLAG_HIDE_SILPH_CO_6F_HP_UP"
+      "flag": "FLAG_HIDE_SILPH_CO_6F_HP_UP",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 1,
       "y": 17,
       "elevation": 3,
@@ -152,7 +151,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_6F_EventScript_ItemXSpecial",
-      "flag": "FLAG_HIDE_SILPH_CO_6F_X_SPECIAL"
+      "flag": "FLAG_HIDE_SILPH_CO_6F_X_SPECIAL",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/SilphCo_7F/map.json
+++ b/data/maps/SilphCo_7F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST_1",
-      "in_connection": false,
       "x": 0,
       "y": 7,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_7F_EventScript_LaprasGuy",
-      "flag": "FLAG_GOT_LAPRAS_FROM_SILPH"
+      "flag": "FLAG_GOT_LAPRAS_FROM_SILPH",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BLUE",
-      "in_connection": false,
       "x": 2,
       "y": 6,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "0x0",
-      "flag": "FLAG_HIDE_SILPH_RIVAL"
+      "flag": "FLAG_HIDE_SILPH_RIVAL",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 13,
       "y": 4,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "SilphCo_7F_EventScript_Grunt3",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
-      "in_connection": false,
       "x": 10,
       "y": 10,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_7F_EventScript_WorkerF",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_DEVON_EMPLOYEE",
-      "in_connection": false,
       "x": 13,
       "y": 14,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_7F_EventScript_WorkerM1",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_DEVON_EMPLOYEE",
-      "in_connection": false,
       "x": 9,
       "y": 14,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_7F_EventScript_WorkerM2",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST_1",
-      "in_connection": false,
       "x": 3,
       "y": 13,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "1",
       "script": "SilphCo_7F_EventScript_Joshua",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 0,
       "y": 12,
       "elevation": 3,
@@ -124,11 +123,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_7F_EventScript_ItemCalcium",
-      "flag": "FLAG_HIDE_SILPH_CO_7F_CALCIUM"
+      "flag": "FLAG_HIDE_SILPH_CO_7F_CALCIUM",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 24,
       "y": 5,
       "elevation": 3,
@@ -138,11 +137,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "SilphCo_7F_EventScript_Grunt1",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 24,
       "y": 15,
       "elevation": 3,
@@ -152,11 +151,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "SilphCo_7F_EventScript_Grunt2",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 3,
       "y": 7,
       "elevation": 3,
@@ -166,11 +165,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "SilphCo_7F_EventScript_PostgameGrunt6",
-      "flag": "FLAG_HIDE_SILPH_POSTGAME_ROCKET"
+      "flag": "FLAG_HIDE_SILPH_POSTGAME_ROCKET",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 0,
       "y": 7,
       "elevation": 3,
@@ -180,11 +179,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "SilphCo_7F_EventScript_PostgameGrunt5",
-      "flag": "FLAG_HIDE_SILPH_POSTGAME_ROCKET"
+      "flag": "FLAG_HIDE_SILPH_POSTGAME_ROCKET",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_GREAT_BALL",
-      "in_connection": false,
       "x": 30,
       "y": 11,
       "elevation": 3,
@@ -194,7 +193,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_7F_EventScript_ItemTM08",
-      "flag": "FLAG_HIDE_SILPH_CO_7F_TM08"
+      "flag": "FLAG_HIDE_SILPH_CO_7F_TM08",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/SilphCo_8F/map.json
+++ b/data/maps/SilphCo_8F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_DEVON_EMPLOYEE",
-      "in_connection": false,
       "x": 2,
       "y": 5,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_8F_EventScript_WorkerM",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST_1",
-      "in_connection": false,
       "x": 9,
       "y": 4,
       "elevation": 3,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "SilphCo_8F_EventScript_Parker",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 10,
       "y": 17,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "5",
       "script": "SilphCo_8F_EventScript_Grunt2",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 28,
       "y": 5,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "SilphCo_8F_EventScript_Grunt1",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST_1",
-      "in_connection": false,
       "x": 29,
       "y": 9,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_8F_EventScript_Scientist",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 24,
       "y": 8,
       "elevation": 3,
@@ -96,7 +95,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_8F_EventScript_ItemIron",
-      "flag": "FLAG_HIDE_SILPH_CO_8F_IRON"
+      "flag": "FLAG_HIDE_SILPH_CO_8F_IRON",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/SilphCo_9F/map.json
+++ b/data/maps/SilphCo_9F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_M",
-      "in_connection": false,
       "x": 1,
       "y": 6,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "5",
       "script": "SilphCo_9F_EventScript_Grunt1",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
-      "in_connection": false,
       "x": 2,
       "y": 16,
       "elevation": 0,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "SilphCo_9F_EventScript_HealWoman",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_MEMBER_F",
-      "in_connection": false,
       "x": 15,
       "y": 18,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "SilphCo_9F_EventScript_Grunt2",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST_1",
-      "in_connection": false,
       "x": 26,
       "y": 16,
       "elevation": 3,
@@ -68,7 +67,8 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
       "script": "SilphCo_9F_EventScript_Ed",
-      "flag": "FLAG_HIDE_SAFFRON_ROCKETS"
+      "flag": "FLAG_HIDE_SAFFRON_ROCKETS",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/VictoryRoad_1F/map.json
+++ b/data/maps/VictoryRoad_1F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_COOL_TRAINER_M",
-      "in_connection": false,
       "x": 5,
       "y": 2,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "VictoryRoad_1F_EventScript_Rolando",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_COOL_TRAINER_F",
-      "in_connection": false,
       "x": 14,
       "y": 6,
       "elevation": 4,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "VictoryRoad_1F_EventScript_Naomi",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 12,
       "y": 3,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "VictoryRoad_1F_EventScript_ItemRareCandy",
-      "flag": "FLAG_HIDE_VICTORY_ROAD_1F_RARE_CANDY"
+      "flag": "FLAG_HIDE_VICTORY_ROAD_1F_RARE_CANDY",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_GREAT_BALL",
-      "in_connection": false,
       "x": 14,
       "y": 1,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "VictoryRoad_1F_EventScript_ItemTM02",
-      "flag": "FLAG_HIDE_VICTORY_ROAD_1F_TM02"
+      "flag": "FLAG_HIDE_VICTORY_ROAD_1F_TM02",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 7,
       "y": 18,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 4,
       "y": 12,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 16,
       "y": 3,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 19,
       "y": 5,
       "elevation": 3,
@@ -124,11 +123,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_12"
+      "flag": "FLAG_TEMP_12",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 10,
       "y": 11,
       "elevation": 3,
@@ -138,11 +137,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_13"
+      "flag": "FLAG_TEMP_13",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 7,
       "y": 5,
       "elevation": 3,
@@ -152,7 +151,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_14"
+      "flag": "FLAG_TEMP_14",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/VictoryRoad_2F/map.json
+++ b/data/maps/VictoryRoad_2F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_MANIAC",
-      "in_connection": false,
       "x": 7,
       "y": 4,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "1",
       "script": "VictoryRoad_2F_EventScript_Dawson",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BLACK_BELT",
-      "in_connection": false,
       "x": 20,
       "y": 11,
       "elevation": 4,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "VictoryRoad_2F_EventScript_Daisuke",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MAN_2",
-      "in_connection": false,
       "x": 31,
       "y": 16,
       "elevation": 4,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "VictoryRoad_2F_EventScript_Nelson",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MAN_3",
-      "in_connection": false,
       "x": 26,
       "y": 6,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "1",
       "script": "VictoryRoad_2F_EventScript_Vincent",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MAN_2",
-      "in_connection": false,
       "x": 36,
       "y": 5,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
       "script": "VictoryRoad_2F_EventScript_Gregory",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 17,
       "y": 6,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "VictoryRoad_2F_EventScript_ItemGuardSpec",
-      "flag": "FLAG_HIDE_VICTORY_ROAD_2F_GUARD_SPEC"
+      "flag": "FLAG_HIDE_VICTORY_ROAD_2F_GUARD_SPEC",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_GREAT_BALL",
-      "in_connection": false,
       "x": 40,
       "y": 7,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "VictoryRoad_2F_EventScript_ItemTM07",
-      "flag": "FLAG_HIDE_VICTORY_ROAD_2F_TM07"
+      "flag": "FLAG_HIDE_VICTORY_ROAD_2F_TM07",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 25,
       "y": 13,
       "elevation": 3,
@@ -124,11 +123,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "VictoryRoad_2F_EventScript_ItemFullHeal",
-      "flag": "FLAG_HIDE_VICTORY_ROAD_2F_FULL_HEAL"
+      "flag": "FLAG_HIDE_VICTORY_ROAD_2F_FULL_HEAL",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_GREAT_BALL",
-      "in_connection": false,
       "x": 14,
       "y": 13,
       "elevation": 3,
@@ -138,11 +137,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "VictoryRoad_2F_EventScript_ItemTM37",
-      "flag": "FLAG_HIDE_VICTORY_ROAD_2F_TM37"
+      "flag": "FLAG_HIDE_VICTORY_ROAD_2F_TM37",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 8,
       "y": 7,
       "elevation": 3,
@@ -152,11 +151,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 6,
       "y": 17,
       "elevation": 3,
@@ -166,11 +165,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 33,
       "y": 19,
       "elevation": 3,
@@ -180,11 +179,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "FLAG_HIDE_VICTORY_ROAD_2F_BOULDER"
+      "flag": "FLAG_HIDE_VICTORY_ROAD_2F_BOULDER",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_COOL_TRAINER_M",
-      "in_connection": false,
       "x": 40,
       "y": 9,
       "elevation": 3,
@@ -194,11 +193,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MoveTutor_DoubleEdge",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 18,
       "y": 2,
       "elevation": 3,
@@ -208,11 +207,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_12"
+      "flag": "FLAG_TEMP_12",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 21,
       "y": 3,
       "elevation": 3,
@@ -222,11 +221,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_13"
+      "flag": "FLAG_TEMP_13",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 12,
       "y": 7,
       "elevation": 3,
@@ -236,11 +235,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_14"
+      "flag": "FLAG_TEMP_14",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 23,
       "y": 1,
       "elevation": 3,
@@ -250,11 +249,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_15"
+      "flag": "FLAG_TEMP_15",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 12,
       "y": 13,
       "elevation": 3,
@@ -264,7 +263,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_16"
+      "flag": "FLAG_TEMP_16",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/VictoryRoad_3F/map.json
+++ b/data/maps/VictoryRoad_3F/map.json
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_COOL_TRAINER_M",
-      "in_connection": false,
       "x": 40,
       "y": 7,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "1",
       "script": "VictoryRoad_3F_EventScript_George",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_COOL_TRAINER_F",
-      "in_connection": false,
       "x": 21,
       "y": 5,
       "elevation": 4,
@@ -40,11 +39,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
       "script": "VictoryRoad_3F_EventScript_Alexa",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_COOL_TRAINER_M",
-      "in_connection": false,
       "x": 10,
       "y": 17,
       "elevation": 3,
@@ -54,11 +53,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "5",
       "script": "VictoryRoad_3F_EventScript_Colby",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_COOL_TRAINER_F",
-      "in_connection": false,
       "x": 11,
       "y": 16,
       "elevation": 3,
@@ -68,11 +67,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "5",
       "script": "VictoryRoad_3F_EventScript_Caroline",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 38,
       "y": 7,
       "elevation": 3,
@@ -82,11 +81,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "VictoryRoad_3F_EventScript_ItemMaxRevive",
-      "flag": "FLAG_HIDE_VICTORY_ROAD_3F_MAX_REVIVE"
+      "flag": "FLAG_HIDE_VICTORY_ROAD_3F_MAX_REVIVE",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_GREAT_BALL",
-      "in_connection": false,
       "x": 12,
       "y": 9,
       "elevation": 3,
@@ -96,11 +95,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "VictoryRoad_3F_EventScript_ItemTM50",
-      "flag": "FLAG_HIDE_VICTORY_ROAD_3F_TM50"
+      "flag": "FLAG_HIDE_VICTORY_ROAD_3F_TM50",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 19,
       "y": 15,
       "elevation": 3,
@@ -110,11 +109,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 33,
       "y": 18,
       "elevation": 0,
@@ -124,11 +123,11 @@
       "trainer_type": "FLAG_HIDE_VICTORY_ROAD_2F_BOULDER",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "FLAG_HIDE_VICTORY_ROAD_3F_BOULDER"
+      "flag": "FLAG_HIDE_VICTORY_ROAD_3F_BOULDER",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 35,
       "y": 13,
       "elevation": 3,
@@ -138,11 +137,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
-      "in_connection": false,
       "x": 32,
       "y": 5,
       "elevation": 3,
@@ -152,11 +151,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_StrengthBoulder",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_COOL_TRAINER_M",
-      "in_connection": false,
       "x": 38,
       "y": 13,
       "elevation": 3,
@@ -166,11 +165,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "1",
       "script": "VictoryRoad_3F_EventScript_Ray",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_COOL_TRAINER_F",
-      "in_connection": false,
       "x": 39,
       "y": 13,
       "elevation": 3,
@@ -180,11 +179,11 @@
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "1",
       "script": "VictoryRoad_3F_EventScript_Tyra",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 7,
       "y": 3,
       "elevation": 3,
@@ -194,11 +193,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_12"
+      "flag": "FLAG_TEMP_12",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 3,
       "y": 8,
       "elevation": 3,
@@ -208,11 +207,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_13"
+      "flag": "FLAG_TEMP_13",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 14,
       "y": 4,
       "elevation": 3,
@@ -222,11 +221,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_14"
+      "flag": "FLAG_TEMP_14",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 17,
       "y": 15,
       "elevation": 3,
@@ -236,11 +235,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_16"
+      "flag": "FLAG_TEMP_16",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 36,
       "y": 19,
       "elevation": 3,
@@ -250,11 +249,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_17"
+      "flag": "FLAG_TEMP_17",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREAKABLE_ROCK",
-      "in_connection": false,
       "x": 26,
       "y": 11,
       "elevation": 3,
@@ -264,11 +263,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_RockSmash",
-      "flag": "FLAG_TEMP_11"
+      "flag": "FLAG_TEMP_11",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 21,
       "y": 12,
       "elevation": 3,
@@ -278,7 +277,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "VictoryRoad_3F_EventScript_ItemPowerStone",
-      "flag": "FLAG_HIDE_VICTORY_ROAD_3F_POWER_STONE"
+      "flag": "FLAG_HIDE_VICTORY_ROAD_3F_POWER_STONE",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/VictoryRoad_MoltresCave/map.json
+++ b/data/maps/VictoryRoad_MoltresCave/map.json
@@ -7,8 +7,8 @@
   "requires_flash": false,
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_UNDERGROUND",
-  "allow_cycling": false,
-  "allow_escaping": false,
+  "allow_cycling": true,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
@@ -16,7 +16,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_MOLTRES",
-      "in_connection": false,
       "x": 4,
       "y": 3,
       "elevation": 3,
@@ -26,11 +25,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "VictoryRoad_MoltresCave_EventScript_Moltres",
-      "flag": "FLAG_HIDE_MOLTRES"
+      "flag": "FLAG_HIDE_MOLTRES",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 4,
       "y": 1,
       "elevation": 3,
@@ -40,7 +39,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "VictoryRoad_MoltresCave_HeatRock",
-      "flag": "FLAG_HIDE_VICTORY_ROAD_HEAT_ROCK"
+      "flag": "FLAG_HIDE_VICTORY_ROAD_HEAT_ROCK",
+      "in_connection": ""
     }
   ],
   "warp_events": [


### PR DESCRIPTION
Fixing some issues and corrected an oversight in Rocket Hideout

- Fixed Looker and Rocket Leader disappearing in the computer. Closes #14
- Dig is now possible in every building that has 3 or more floors. Closes #46
- Updated README.MD with latest hash.
- Changed a barrier to be set if Giovanni isn’t defeated instead of Grunt 12, preventing the barrier from coming down if Grunt 12 was never fought before it had to leave Rocket Hideout.
