### PR TITLE
preparing for prereleasev1.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # PokéClassic
 ## Status: Version 1.4 released!
-### DaniRainbow's fork: pre-release v1.4.2 available to test!
+### DaniRainbow's fork: pre-release v1.4.3 available to test!
 
 PokéClassic is a recreation of Pokémon Yellow, recreated in the Pokémon Emerald engine. Revisit your classic adventures through Kanto with new features, questlines, and post game content!
 This fork was created to address the unfixed issues with the original repository and accomplished an unofficial PokéClassic 1.4 release. v1.5 not planned at this time but may happen if there are more reported issues or appropriate enhancements.
 # Getting PokeClassic
 This repository builds the following ROM:
 
-* pokeemerald.gba `sha1: 9E46813F946DB5CB489E7E7E44FBF644069C8567`
+* pokeemerald.gba `sha1: F078841A70E15F6EA4A1A7EA30A681FC603CB83A`
 
-**updated 4/14/2025**
+**updated 4/18/2025**
 
 To compile this ROM yourself, see [Pret's Installation Guide](https://github.com/pret/pokeemerald/blob/master/INSTALL.md) on how to get started with the decompilations. Then, clone this branch and build the ROM by changing "pokeemerald" to "pokeclassic" in the instructions.
 

--- a/data/maps/LavenderTown/map.json
+++ b/data/maps/LavenderTown/map.json
@@ -32,7 +32,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_BOY_2",
-      "in_connection": false,
       "x": 10,
       "y": 7,
       "elevation": 3,
@@ -42,11 +41,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "LavenderTown_EventScript_Boy",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LITTLE_GIRL",
-      "in_connection": false,
       "x": 19,
       "y": 10,
       "elevation": 3,
@@ -56,11 +55,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "LavenderTown_EventScript_LittleGirl",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BREEDER_F",
-      "in_connection": false,
       "x": 12,
       "y": 12,
       "elevation": 3,
@@ -70,7 +69,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "LavenderTown_EventScript_WorkerM",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/PalletTown/map.json
+++ b/data/maps/PalletTown/map.json
@@ -27,7 +27,6 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_MOM",
-      "in_connection": false,
       "x": 6,
       "y": 8,
       "elevation": 3,
@@ -37,11 +36,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "NULL",
-      "flag": "FLAG_HIDE_MOM_PALLET_TOWN"
+      "flag": "FLAG_HIDE_MOM_PALLET_TOWN",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_4",
-      "in_connection": false,
       "x": 3,
       "y": 10,
       "elevation": 3,
@@ -51,11 +50,11 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PalletTown_EventScript_Lady",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_FAT_MAN",
-      "in_connection": false,
       "x": 13,
       "y": 17,
       "elevation": 3,
@@ -65,7 +64,8 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PalletTown_EventScript_FatMan",
-      "flag": "0"
+      "flag": "0",
+      "in_connection": ""
     }
   ],
   "warp_events": [

--- a/data/maps/ViridianCity/map.json
+++ b/data/maps/ViridianCity/map.json
@@ -14,19 +14,19 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_ROUTE1",
+      "direction": "down",
       "offset": 12,
-      "direction": "down"
+      "map": "MAP_ROUTE1"
     },
     {
-      "map": "MAP_ROUTE22",
+      "direction": "left",
       "offset": 10,
-      "direction": "left"
+      "map": "MAP_ROUTE22"
     },
     {
-      "map": "MAP_ROUTE2",
+      "direction": "up",
       "offset": 12,
-      "direction": "up"
+      "map": "MAP_ROUTE2"
     }
   ],
   "object_events": [
@@ -42,7 +42,7 @@
       "trainer_sight_or_berry_tree_id": "0",
       "script": "NULL",
       "flag": "FLAG_HIDE_OFFICER_JENNY_VIRIDIAN_CITY",
-      "in_connection": false
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_EXPERT_M",
@@ -56,7 +56,7 @@
       "trainer_sight_or_berry_tree_id": "0",
       "script": "ViridianCity_EventScript_OldMan",
       "flag": "0",
-      "in_connection": false
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BOY_3",
@@ -70,7 +70,7 @@
       "trainer_sight_or_berry_tree_id": "0",
       "script": "ViridianCity_EventScript_Boy",
       "flag": "0",
-      "in_connection": false
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_4",
@@ -84,7 +84,7 @@
       "trainer_sight_or_berry_tree_id": "0",
       "script": "ViridianCity_EventScript_Woman",
       "flag": "0",
-      "in_connection": false
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_MAN",
@@ -98,7 +98,7 @@
       "trainer_sight_or_berry_tree_id": "0",
       "script": "ViridianCity_EventScript_OldMan2",
       "flag": "0",
-      "in_connection": false
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_FAT_MAN",
@@ -112,7 +112,7 @@
       "trainer_sight_or_berry_tree_id": "0",
       "script": "MoveTutor_DreamEater",
       "flag": "0",
-      "in_connection": false
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
@@ -126,7 +126,7 @@
       "trainer_sight_or_berry_tree_id": "0",
       "script": "ViridianCity_FindItem_Potion",
       "flag": "FLAG_VIRIDIAN_CITY_POTION",
-      "in_connection": false
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CUTTABLE_TREE",
@@ -140,7 +140,7 @@
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_CutTree",
       "flag": "FLAG_TEMP_12",
-      "in_connection": false
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CUTTABLE_TREE",
@@ -154,7 +154,7 @@
       "trainer_sight_or_berry_tree_id": "0",
       "script": "EventScript_CutTree",
       "flag": "FLAG_TEMP_11",
-      "in_connection": false
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_YOUNGSTER",
@@ -168,7 +168,7 @@
       "trainer_sight_or_berry_tree_id": "0",
       "script": "ViridianCity_EventScript_Youngster",
       "flag": "0",
-      "in_connection": false
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BERRY_TREE",
@@ -182,7 +182,7 @@
       "trainer_sight_or_berry_tree_id": "BERRY_TREE_VIRIDIAN_SOIL",
       "script": "BerryTreeScript",
       "flag": "0",
-      "in_connection": false
+      "in_connection": ""
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_POKEFAN_M",
@@ -196,7 +196,7 @@
       "trainer_sight_or_berry_tree_id": "0",
       "script": "ViridianCity_EventScript_BerryTreeGuy",
       "flag": "0",
-      "in_connection": false
+      "in_connection": ""
     }
   ],
   "warp_events": [
@@ -205,35 +205,35 @@
       "y": 26,
       "elevation": 0,
       "dest_map": "MAP_VIRIDIAN_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": "0"
+      "dest_warp_id": 0
     },
     {
       "x": 36,
       "y": 19,
       "elevation": 0,
       "dest_map": "MAP_VIRIDIAN_CITY_MART",
-      "dest_warp_id": "0"
+      "dest_warp_id": 0
     },
     {
       "x": 25,
       "y": 18,
       "elevation": 0,
       "dest_map": "MAP_VIRIDIAN_CITY_SCHOOL",
-      "dest_warp_id": "0"
+      "dest_warp_id": 0
     },
     {
       "x": 25,
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_VIRIDIAN_CITY_HOUSE",
-      "dest_warp_id": "0"
+      "dest_warp_id": 0
     },
     {
       "x": 36,
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_VIRIDIAN_CITY_GYM",
-      "dest_warp_id": "0"
+      "dest_warp_id": 0
     }
   ],
   "coord_events": [

--- a/data/scripts/surf.inc
+++ b/data/scripts/surf.inc
@@ -1,4 +1,5 @@
 EventScript_UseSurf::
+	goto_if_unset FLAG_BADGE05_GET, EventScript_ScarySeas
 	checkpartymove MOVE_SURF
 	goto_if_eq VAR_RESULT, PARTY_SIZE, EventScript_EndUseSurf
 	bufferpartymonnick STR_VAR_1, VAR_RESULT
@@ -12,3 +13,14 @@ EventScript_ReleaseUseSurf::
 	releaseall
 EventScript_EndUseSurf::
 	end
+
+EventScript_ScarySeas::
+	msgbox EventScript_ScarySeasText, MSGBOX_DEFAULT
+	waitmessage
+	releaseall
+	end
+
+EventScript_ScarySeasText:
+	.string "The water before you looks inviting.\p"
+	.string "Perhaps surfing is in your future.$"
+

--- a/src/data/wild_encounters.json
+++ b/src/data/wild_encounters.json
@@ -2945,7 +2945,7 @@
             ]
           },
           "water_mons": {
-            "encounter_rate": 0,
+            "encounter_rate": 10,
             "mons": [
               {
                 "min_level": 15,
@@ -3119,7 +3119,7 @@
             ]
           },
           "water_mons": {
-            "encounter_rate": 0,
+            "encounter_rate": 10,
             "mons": [
               {
                 "min_level": 15,

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2513,7 +2513,7 @@ static void RemoveLevelUpStatsWindow(void)
 
 static void SetPartyMonSelectionActions(struct Pokemon *mons, u8 slotId, u8 action)
 {
-    u8 i;
+    u32 i;
 
     if (action == ACTIONS_NONE)
     {
@@ -2529,7 +2529,7 @@ static void SetPartyMonSelectionActions(struct Pokemon *mons, u8 slotId, u8 acti
 
 static void SetPartyMonFieldSelectionActions(struct Pokemon *mons, u8 slotId)
 {
-    u8 i, j;
+    u32 i, j;
 
     sPartyMenuInternal->numActions = 0;
     AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, MENU_SUMMARY);
@@ -2542,9 +2542,9 @@ static void SetPartyMonFieldSelectionActions(struct Pokemon *mons, u8 slotId)
             if (GetMonData(&mons[slotId], i + MON_DATA_MOVE1) == sFieldMoves[j])
             {
                 // If Mon already knows FLY and the HM is in the bag, prevent it from being added to action list
-                if (sFieldMoves[j] != FIELD_MOVE_FLY || !CheckBagHasItem(ITEM_HM02_FLY, 1)){
+                if (sFieldMoves[j] != MOVE_FLY || !CheckBagHasItem(ITEM_HM02_FLY, 1)){
 					// If Mon already knows FLASH and the HM is in the bag, prevent it from being added to action list
-					if (sFieldMoves[j] != MOVE_FLASH || !CheckBagHasItem(ITEM_HM05_FLASH, 1)){ 
+				    if (sFieldMoves[j] != MOVE_FLASH || !CheckBagHasItem(ITEM_HM05_FLASH, 1)){ 
 						AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, j + MENU_FIELD_MOVES);
                     }
                 }
@@ -2553,12 +2553,28 @@ static void SetPartyMonFieldSelectionActions(struct Pokemon *mons, u8 slotId)
         }
     }
 
+    // Legend for MENU_FIELD_MOVES order
+    //Flash         = 0
+    //Cut           = 1
+    //Fly           = 2
+    //Strength      = 3
+    //Surf          = 4
+    //Rock Smash    = 5
+    //Dive          = 6
+    //Waterfall     = 7
+    //Teleport      = 8
+    //Dig           = 9
+    //Secret Power  = 10
+    //Milk Drink    = 11
+    //Soft-Boiled   = 12
+    //Sweet Scent   = 13
+    //
     // If Mon can learn HM02 and action list consists of < 4 moves, add FLY to action list
-    if (sPartyMenuInternal->numActions < 5 && CanMonLearnTMHM(&mons[slotId], ITEM_HM02 - ITEM_TM01) && CheckBagHasItem(ITEM_HM02_FLY, 1)) 
-    AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 5 + MENU_FIELD_MOVES);
+    if (sPartyMenuInternal->numActions < 5 && CanMonLearnTMHM(&mons[slotId], ITEM_HM02 - ITEM_TM01) && CheckBagHasItem(ITEM_HM02_FLY, 1) && FlagGet(FLAG_BADGE03_GET) == TRUE)
+        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 0 + MENU_FIELD_MOVES);
     // If Mon can learn HM05 and action list consists of < 4 moves, add FLASH to action list
     if (sPartyMenuInternal->numActions < 5 && CanMonLearnTMHM(&mons[slotId], ITEM_HM05 - ITEM_TM01) && CheckBagHasItem(ITEM_HM05_FLASH, 1)) 
-        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 1 + MENU_FIELD_MOVES);
+        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 0 + MENU_FIELD_MOVES);
     // If Mon can learn HM06 and action list consists of <4 moves, add ROCK SMASH to action list
 	//if (sPartyMenuInternal->numActions < 5 && CanMonLearnTMHM(&mons[slotId], ITEM_HM06 - ITEM_TM01) && CheckBagHasItem(ITEM_HM06_ROCK_SMASH, 1)) 
 		//AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 5 + MENU_FIELD_MOVES);

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1766,19 +1766,6 @@ bool8 ScrCmd_checkpartymove(struct ScriptContext *ctx)
     u8 i;
     u16 moveId = ScriptReadHalfword(ctx);
 
-    gSpecialVar_Result = PARTY_SIZE;
-    for (i = 0; i < PARTY_SIZE; i++)
-    {
-        u16 species = GetMonData(&gPlayerParty[i], MON_DATA_SPECIES, NULL);
-        if (!species)
-            break;
-        if (!GetMonData(&gPlayerParty[i], MON_DATA_IS_EGG) && MonKnowsMove(&gPlayerParty[i], moveId) == TRUE)
-        {
-            gSpecialVar_Result = i;
-            gSpecialVar_0x8004 = species;
-            break;
-        }
-    }
     if (gSpecialVar_Result == PARTY_SIZE && (CheckBagHasItem(MoveToHM(moveId), 1))){
         for (i = 0; i < PARTY_SIZE; i++)
         {


### PR DESCRIPTION
-Updated data/scripts/surf.inc to prevent Surfing before acquiring the 5th Badge.
-Restored Surf encountered on Route 10 for Day and Night.
-Made it possible to use Fly without knowing the move as long as you have the HM and the associated badge. #68
-Prevented the game from showing Fly twice in the Field Moves if the pokemon knew Fly
-Updated syntax for checking if player’s pokemon knows Flash.
-Added a Legend for the correct number for MENU_FIELD_MOVES
-Flash will appear as an option in the Field Menu (needed in Emerald, may not be needed in Pokemon Classic)
-Removed seemingly unnecessary information from src/scrcmd.c (time will tell if that’s a problem, hence the pre-release)
-Updated README.MD with latest hash, revision date, and pre-release
