### PR TITLE
Mewtwo and More Field Moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This fork was created to address the unfixed issues with the original repository
 # Getting PokeClassic
 This repository builds the following ROM:
 
-* pokeemerald.gba `sha1: F078841A70E15F6EA4A1A7EA30A681FC603CB83A`
+* pokeemerald.gba `sha1: 660D40A86CCB043A99763233BDC9B16DE1732289`
 
-**updated 4/18/2025**
+**updated 4/19/2025**
 
 To compile this ROM yourself, see [Pret's Installation Guide](https://github.com/pret/pokeemerald/blob/master/INSTALL.md) on how to get started with the decompilations. Then, clone this branch and build the ROM by changing "pokeemerald" to "pokeclassic" in the instructions.
 
-Otherwise, patch files will occasionaly be released here. These will be slower to release than pulling updates yourself. To patch this game, you will need to provide your own ROM.
+Otherwise, patch files will occasionally be released here. These will be slower to release than pulling updates yourself. To patch this game, you will need to provide your own ROM.
 ## Interested in bug testing or have a bug you wish to report?
 
 Please use the following template when you submit a new issue: 

--- a/data/maps/CeruleanCave_B1F/scripts.inc
+++ b/data/maps/CeruleanCave_B1F/scripts.inc
@@ -53,7 +53,7 @@ CeruleanCave_EventScript_Mewtwo::
 	playmoncry SPECIES_MEWTWO, CRY_MODE_ENCOUNTER
 	waitmoncry
 	delay 20
-	seteventmon SPECIES_MEWTWO, 50
+	seteventmon SPECIES_MEWTWO, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
 	waitstate

--- a/data/maps/CeruleanCity/scripts.inc
+++ b/data/maps/CeruleanCity/scripts.inc
@@ -736,7 +736,7 @@ CeruleanCity_EventScript_BillCallsPlayer::
 
 CeruleanCity_Text_DexNavCall::
 	.string "???: Hey, is this {PLAYER}?\p"
-	.string "Bill: Yeah, it's BilL!\p"
+	.string "Bill: Yeah, it's Bill!\p"
 	.string "I had to email Prof. Oak for your\n"
 	.string "number, I hope that's OK!\p"
 	.string "My brain must have been a little\n"

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2569,12 +2569,18 @@ static void SetPartyMonFieldSelectionActions(struct Pokemon *mons, u8 slotId)
     //Soft-Boiled   = 12
     //Sweet Scent   = 13
     //
-    // If Mon can learn HM02 and action list consists of < 4 moves, add FLY to action list
+    // If Mon can learn HM02 and action list consists of < 4 moves and player has FLY HM and player has the associated Badge, add FLY to action list
     if (sPartyMenuInternal->numActions < 5 && CanMonLearnTMHM(&mons[slotId], ITEM_HM02 - ITEM_TM01) && CheckBagHasItem(ITEM_HM02_FLY, 1) && FlagGet(FLAG_BADGE03_GET) == TRUE)
-        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 0 + MENU_FIELD_MOVES);
-    // If Mon can learn HM05 and action list consists of < 4 moves, add FLASH to action list
+        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 2 + MENU_FIELD_MOVES);
+    // If Mon can learn HM05 and action list consists of < 4 moves and player has FLASH HM, add FLASH to action list
     if (sPartyMenuInternal->numActions < 5 && CanMonLearnTMHM(&mons[slotId], ITEM_HM05 - ITEM_TM01) && CheckBagHasItem(ITEM_HM05_FLASH, 1)) 
         AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 0 + MENU_FIELD_MOVES);
+    // If Mon can learn TM28 and action list consists of < 4 moves and player recovered the DIG TM, add DIG to action list
+    if (sPartyMenuInternal->numActions < 5 && CanMonLearnTMHM(&mons[slotId], ITEM_TM28 - ITEM_TM01) && FlagGet(FLAG_RECOVERED_STOLEN_TM) == TRUE)
+        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 9 + MENU_FIELD_MOVES);
+    // If Mon can learn TM29 (is a Psychic type and could therefore learn Teleport) and action list consists of < 4 moves, add TELEPORT to action list
+    if (sPartyMenuInternal->numActions < 5 && CanMonLearnTMHM(&mons[slotId], ITEM_TM29 - ITEM_TM01))
+        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 8 + MENU_FIELD_MOVES);
     // If Mon can learn HM06 and action list consists of <4 moves, add ROCK SMASH to action list
 	//if (sPartyMenuInternal->numActions < 5 && CanMonLearnTMHM(&mons[slotId], ITEM_HM06 - ITEM_TM01) && CheckBagHasItem(ITEM_HM06_ROCK_SMASH, 1)) 
 		//AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 5 + MENU_FIELD_MOVES);

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2563,7 +2563,7 @@ static void SetPartyMonFieldSelectionActions(struct Pokemon *mons, u8 slotId)
     //Dive          = 6
     //Waterfall     = 7
     //Teleport      = 8
-    //Dig           = 9
+    //Dig           = 9     FLAG_RECOVERED_STOLEN_TM
     //Secret Power  = 10
     //Milk Drink    = 11
     //Soft-Boiled   = 12


### PR DESCRIPTION
-Updated the Mewtwo encounter in Cerulean Cave to be level 70
-Decapitalized an L during a DexNav call with Bill (BilL)
-Updated the Legend in partymenu.c to show the flag associated with Dig
-Added more specific definitions of when field moves are added to the menu
-Added the ability to use Dig without knowing it after recovering the stolen ™
-Added the ability for any Psychic type pokemon to use Teleport without knowing it
-updated README.MD with latest HASH, revision date, and corrected a spelling error from v1.3
-content complete for prerelease v1.4.4
